### PR TITLE
Modified: unicode escape BULLET instead of adding magic comment

### DIFF
--- a/lib/git_trend/scraper.rb
+++ b/lib/git_trend/scraper.rb
@@ -53,7 +53,7 @@ module GitTrend
     end
 
     def extract_lang_and_star_from_meta(text)
-      meta_data = text.split('\u2022').map { |x| x.gsub("\n", '').strip }
+      meta_data = text.split(0x2022.chr 'utf-8').map { |x| x.gsub("\n", '').strip }
       if meta_data.size == 3
         lang = meta_data[0]
         star_count = meta_data[1].gsub(',', '').to_i


### PR DESCRIPTION
fixed following error for ruby 19.

```
/Users/gdansk/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/git-trend-0.1.1/lib/git_trend/cli.rb:24:in `list': /Users/gdansk/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/git-trend-0.1.1/lib/git_trend/scraper.rb:54: invalid multibyte char (US-ASCII) (SyntaxError)
/Users/gdansk/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/git-trend-0.1.1/lib/git_trend/scraper.rb:54: invalid multibyte char (US-ASCII)
/Users/gdansk/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/git-trend-0.1.1/lib/git_trend/scraper.rb:54: syntax error, unexpected $end, expecting ')'
      meta_data = text.split('•').map { |x| x.gsub("\n", '').strip }
                                ^
```
