### PR TITLE
Use Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Run rspec, rubocop
+name: CI
 
 on:
   push:
@@ -75,7 +75,8 @@ jobs:
       - name: Run lint
         run: bundle exec rubocop
 
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v2.2.3
-        # with:
-        #   github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage/.resultset.json
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -9,9 +9,7 @@ gem "rubocop-performance", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
 
-gem "coveralls", require: false
 gem "irb", require: false
 gem "rspec", require: false
 gem "simplecov", require: false
-gem "simplecov-lcov", require: false
-gem "webmock", "~> 3.18.1", require: false
+gem "webmock", require: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![Build Status](https://travis-ci.com/rochefort/git-trend.svg?branch=master)](https://travis-ci.com/rochefort/git-trend)
-[![Coverage Status](https://coveralls.io/repos/github/rochefort/git-trend/badge.svg?branch=master)](https://coveralls.io/github/rochefort/git-trend?branch=master)
-[![Code Climate](https://img.shields.io/codeclimate/maintainability/rochefort/git-trend.svg)](https://codeclimate.com/github/rochefort/git-trend/maintainability)
+[![codecov](https://codecov.io/gh/rochefort/git-trend/graph/badge.svg?token=rbh4fONhKx)](https://codecov.io/gh/rochefort/git-trend)
 [![Gem Version](http://img.shields.io/gem/v/git-trend.svg?style=flat)](http://badge.fury.io/rb/git-trend)
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,13 +14,8 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-# require "coveralls"
-# Coveralls.wear!
-
-require "coveralls"
 require "simplecov"
-require "webmock/rspec"
-require "git_trend"
+# require "simplecov-cobertura"
 
 # require "codeclimate-test-reporter"
 dir = File.join(ENV["CIRCLE_ARTIFACTS"] || "coverage")
@@ -29,11 +24,18 @@ SimpleCov.coverage_dir(dir)
 SimpleCov.start do
   add_filter "/spec/"
 
-  formatter SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter,
-  ])
+  if ENV["CI"]
+    formatter SimpleCov::Formatter::SimpleFormatter
+  else
+    formatter SimpleCov::Formatter::MultiFormatter.new([
+      SimpleCov::Formatter::SimpleFormatter,
+      SimpleCov::Formatter::HTMLFormatter,
+    ])
+  end
 end
+
+require "webmock/rspec"
+require "git_trend"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Since coverall is no longer available, we have migrated to codecov on Github Actions.